### PR TITLE
Jz/feature/add support for blog name

### DIFF
--- a/client/src/components/AppProvider.jsx
+++ b/client/src/components/AppProvider.jsx
@@ -12,37 +12,27 @@ class AppProvider extends Component {
     error: null,
     url: '',
     selector: '',
+    blogName: '',
     pagination: '',
     hubSpotPosts: [],
     hubspotPostswImages: [],
     uploadDone: false
   };
 
-  handleURLChange = evt => {
+  handleInputChange = evt => {
+    const { name, value } = evt.target;
     this.setState({
-      url: evt.target.value
-    });
-  };
-
-  handleSelectorChange = evt => {
-    this.setState({
-      selector: evt.target.value
-    });
-  };
-
-  handlePaginationChange = evt => {
-    this.setState({
-      pagination: evt.target.value
+      [name]: value
     });
   };
 
   handleFetch = () => {
-    const { url, selector, pagination } = this.state;
+    const { url, selector, blogName, pagination } = this.state;
     this.setState({
       loading: true,
       error: null
     });
-    axios.post('/api/v1/website', { url, selector, pagination }).then(
+    axios.post('/api/v1/website', { url, selector, blogName, pagination }).then(
       res =>
         this.setState({
           data: res.data,
@@ -113,6 +103,7 @@ class AppProvider extends Component {
       error,
       url,
       selector,
+      blogName,
       pagination,
       hubSpotPosts,
       hubspotPostswImages,
@@ -128,14 +119,13 @@ class AppProvider extends Component {
           error,
           url,
           selector,
+          blogName,
           pagination,
           hubSpotPosts,
           hubspotPostswImages,
           uploadDone,
           confettiActive,
-          handleURLChange: this.handleURLChange,
-          handleSelectorChange: this.handleSelectorChange,
-          handlePaginationChange: this.handlePaginationChange,
+          handleInputChange: this.handleInputChange,
           handleFetch: this.handleFetch,
           handlePosts: this.handlePosts,
           handleImages: this.handleImages,

--- a/client/src/components/AppProvider.jsx
+++ b/client/src/components/AppProvider.jsx
@@ -27,12 +27,12 @@ class AppProvider extends Component {
   };
 
   handleFetch = () => {
-    const { url, selector, blogName, pagination } = this.state;
+    const { url, selector, pagination } = this.state;
     this.setState({
       loading: true,
       error: null
     });
-    axios.post('/api/v1/website', { url, selector, blogName, pagination }).then(
+    axios.post('/api/v1/website', { url, selector, pagination }).then(
       res =>
         this.setState({
           data: res.data,
@@ -47,9 +47,9 @@ class AppProvider extends Component {
   };
 
   handlePosts = () => {
-    const { data } = this.state;
+    const { data, blogName } = this.state;
     this.setState({ loading: true, error: null });
-    axios.post('/api/v1/posts', { postData: data }).then(
+    axios.post('/api/v1/posts', { postData: data, blogName }).then(
       res =>
         this.setState({
           hubSpotPosts: res.data,

--- a/client/src/components/WebsiteForm.jsx
+++ b/client/src/components/WebsiteForm.jsx
@@ -15,19 +15,18 @@ const styles = {
 const WebsiteForm = ({
   url,
   selector,
+  blogName,
   pagination,
   classes,
-  handleURLChange,
-  handleSelectorChange,
-  handlePaginationChange,
+  handleInputChange,
   handleNext
 }) => (
   <div>
     <ValidatorForm onSubmit={handleNext}>
       <TextValidator
         label="Website URL"
-        onChange={handleURLChange}
-        name="website"
+        onChange={handleInputChange}
+        name="url"
         type="website"
         validators={['isURL', 'required']}
         errorMessages={['this field is required']}
@@ -40,14 +39,21 @@ const WebsiteForm = ({
         validators={['isEmpty', 'required']}
         errorMessages={['this field is required']}
         value={selector}
-        onChange={handleSelectorChange}
+        onChange={handleInputChange}
+      />
+      <TextValidator
+        label="Blog Name"
+        name="blogName"
+        type="name"
+        value={blogName}
+        onChange={handleInputChange}
       />
       <TextValidator
         label="Pagination"
         name="pagination"
         type="pagination"
         value={pagination}
-        onChange={handlePaginationChange}
+        onChange={handleInputChange}
       />
       <Button className={classes.button} type="submit" variant="contained" color="primary">
         Get Website Data
@@ -59,11 +65,10 @@ const WebsiteForm = ({
 WebsiteForm.propTypes = {
   url: PropTypes.string.isRequired,
   selector: PropTypes.string.isRequired,
+  blogName: PropTypes.string.isRequired,
   pagination: PropTypes.string.isRequired,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
-  handleURLChange: PropTypes.func.isRequired,
-  handleSelectorChange: PropTypes.func.isRequired,
-  handlePaginationChange: PropTypes.func.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired
 };
 

--- a/client/src/containers/WebsiteFormContainer.jsx
+++ b/client/src/containers/WebsiteFormContainer.jsx
@@ -31,10 +31,9 @@ class WebsiteFormContainer extends Component {
           <WebsiteForm
             url={context.url}
             selector={context.selector}
+            blogName={context.blogName}
             pagination={context.pagination}
-            handleURLChange={context.handleURLChange}
-            handleSelectorChange={context.handleSelectorChange}
-            handlePaginationChange={context.handlePaginationChange}
+            handleInputChange={context.handleInputChange}
             handleNext={handleNext}
           />
         )}

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -7,7 +7,7 @@ const {
   validationResult
 } = require('express-validator/check');
 const {
-  cleanSlug
+  createSlug
 } = require('../utils');
 
 let ACCESS_TOKEN = {};
@@ -77,7 +77,7 @@ module.exports = app => {
   Function takes in an array of objects
   and returns the return content id from the slug
   ============================ */
-  const getPostsArray = (postData) => {
+  const getPostsArray = (postData, blogName) => {
     const headers = {
       Authorization: `Bearer ${ACCESS_TOKEN}`,
       'Content-Type': 'application/json'
@@ -86,7 +86,7 @@ module.exports = app => {
       let slug = data.slug;
       let featuredImage = data.featuredImage;
       if (slug && featuredImage) {
-        slug = cleanSlug(slug);
+        slug = createSlug(slug, blogName);
         return axios.get(blogPostURL, {
           headers: headers,
           params: {
@@ -112,7 +112,8 @@ module.exports = app => {
   app.post('/api/v1/posts', async (req, res) => {
     try {
       const postData = req.body.postData;
-      const results = await axios.all(getPostsArray(postData))
+      const blogName = req.body.blogName;
+      const results = await axios.all(getPostsArray(postData, blogName))
       if ([].concat(...results).length === 0) {
         res.sendStatus(400);
       }

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@ const {
   URL
 } = require('url');
 
-const cleanSlug = (slug) => {
+const createSlug = (slug, blogName) => {
   if (slug) {
     slug = normalizeUrl(slug, {
       removeTrailingSlash: true
@@ -13,9 +13,12 @@ const cleanSlug = (slug) => {
     slug = new URL(slug);
     slug = slug.pathname;
     slug = removeLeadingSlash(slug);
+    if (!slug.includes(blogName)) {
+      return `${blogName}/${slug}`
+    }
     return slug;
   }
   return;
 }
 
-module.exports.cleanSlug = cleanSlug;
+module.exports.createSlug = createSlug;


### PR DESCRIPTION
### Adds support for Blog Name

A lot of times the external blog and the Hubspot blog do not have the same slug such as `blog` at the end of the URL. This makes it possible to take posts from one blog and then add it to another blog with the slug being different. 

We will be able to write in the blog name to the form and this will allow the tool to figure out which HubSpot blog should be updated with the data. 