### PR TITLE
disabled next button while data is loading

### DIFF
--- a/client/src/components/Results.jsx
+++ b/client/src/components/Results.jsx
@@ -29,7 +29,9 @@ const Results = ({ uploadDone, classes }) => (
   <div className={classes.root}>
     <ConfettiComponent confettiActive={uploadDone} />
     <Card className={classes.card}>
-      <CardContent className={classes.cardContent}>{uploadDone}</CardContent>
+      <CardContent className={classes.cardContent}>
+        {uploadDone ? 'Successfully updated your posts!! 🚀🚀' : 'Updating posts...'}
+      </CardContent>
     </Card>
   </div>
 );

--- a/client/src/components/StepperButtons.jsx
+++ b/client/src/components/StepperButtons.jsx
@@ -11,8 +11,14 @@ const styles = {
   }
 };
 
-const StepperButtons = ({ data, activeStep, handlePrevious, handleNext, handleReset, classes }) => {
-  const disableButton = !data.length;
+const StepperButtons = ({
+  loading,
+  activeStep,
+  handlePrevious,
+  handleNext,
+  handleReset,
+  classes
+}) => {
   return (
     <React.Fragment>
       {activeStep >= 1 && (
@@ -30,7 +36,7 @@ const StepperButtons = ({ data, activeStep, handlePrevious, handleNext, handleRe
             <Button
               className={classes.button}
               variant="contained"
-              disabled={disableButton}
+              disabled={loading}
               color="primary"
               onClick={activeStep === 4 ? handleReset : handleNext}
             >
@@ -44,7 +50,7 @@ const StepperButtons = ({ data, activeStep, handlePrevious, handleNext, handleRe
 };
 
 StepperButtons.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  loading: PropTypes.bool.isRequired,
   activeStep: PropTypes.number.isRequired,
   handlePrevious: PropTypes.func.isRequired,
   handleNext: PropTypes.func.isRequired,

--- a/client/src/components/StepperHelpCard.jsx
+++ b/client/src/components/StepperHelpCard.jsx
@@ -41,7 +41,7 @@ class StepperHelpCard extends Component {
       case 3:
         return 'Awesome! Images are uploaded into HubSpot';
       case 4:
-        return 'Upload complete!🚀🚀 Your posts have been updated';
+        return 'Updating your HubSpot Posts!!';
       default:
         return null;
     }

--- a/client/src/containers/StepperButtonsContainer.jsx
+++ b/client/src/containers/StepperButtonsContainer.jsx
@@ -8,12 +8,7 @@ import StepperButtons from '../components/StepperButtons';
 const StepperButtonsContainer = props => {
   return (
     <AppContext.Consumer>
-      {context => (
-        <StepperButtons
-          data={context.data || context.hubSpotPosts || context.hubspotPostswImages}
-          {...props}
-        />
-      )}
+      {context => <StepperButtons loading={context.loading} {...props} />}
     </AppContext.Consumer>
   );
 };

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -143,7 +143,10 @@ module.exports = app => {
     return postData.map((data) => {
       const slug = data.slug;
       const id = data.id;
-      const featuredImage = cleanBackgroundImageURL(data.featuredImage, backgroundImage);
+      if (backgroundImage === "true") {
+        const featuredImage = cleanBackgroundImageURL(data.featuredImage);
+      }
+      const featuredImage = data.featuredImage;
       return axios({
         method: 'post',
         headers: headers,

--- a/utils.js
+++ b/utils.js
@@ -21,8 +21,8 @@ const createSlug = (slug, blogName) => {
   return;
 }
 
-const cleanBackgroundImageURL = (featuredImage, backgroundImage) => {
-  if (featuredImage && backgroundImage === "true") {
+const cleanBackgroundImageURL = (featuredImage) => {
+  if (featuredImage) {
     return featuredImage
       .replace('background-image:', '')
       .match(/\((.*?)\)/)[1]


### PR DESCRIPTION
### Disabled next button while data is loading

This feature will make sure you cannot hit the next button while the app is loading. This will make sure all the data is present before you can proceed with the next step. 

#### Other fixes

- Fixed verbiage on results page

- Adds success and error message on results page